### PR TITLE

Feat: Enhance hello JSP page with HTML5 doctype


### DIFF
--- a/backend/src/main/java/com/example/monolith/controller/JspController.java
+++ b/backend/src/main/java/com/example/monolith/controller/JspController.java
@@ -3,9 +3,18 @@ package com.example.monolith.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+/**
+ * Controller responsible for handling JSP view-related endpoints.
+ * Maps HTTP requests to JSP views in the application.
+ */
 @Controller
 public class JspController {
 
+    /**
+     * Returns the "hello" JSP view when /jsp/hello endpoint is accessed.
+     *
+     * @return the view name to be resolved by the view resolver
+     */
     @GetMapping("/jsp/hello")
     public String helloJsp() {
         return "hello";

--- a/backend/src/main/resources/templates/hello.jsp
+++ b/backend/src/main/resources/templates/hello.jsp
@@ -1,7 +1,12 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<html>
-<head><title>Hello JSP</title></head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello JSP</title>
+</head>
 <body>
-<h2>Hello from JSP!</h2>
+    <h2>Hello from JSP!</h2>
 </body>
 </html>

--- a/backend/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/backend/src/main/webapp/WEB-INF/views/hello.jsp
@@ -1,7 +1,12 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<html>
-<head><title>Hello JSP</title></head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello JSP</title>
+</head>
 <body>
-<h2>Hello from JSP!</h2>
+    <h2>Hello from JSP!</h2>
 </body>
 </html>


### PR DESCRIPTION

This PR enhances the `hello.jsp` page by:

-   Adding the HTML5 doctype declaration (`<!DOCTYPE html>`) to ensure the page is rendered in standards mode.
-   Including a viewport meta tag (`<meta name="viewport" content="width=device-width, initial-scale=1.0">`) for better responsive design across different devices.
-   Setting the character set to UTF-8 (`<meta charset="UTF-8">`) to support a wider range of characters.

These changes improve the page's compatibility and rendering consistency across various browsers and devices.
